### PR TITLE
Add support for raw oem images

### DIFF
--- a/containment-rpm-pxe.changes
+++ b/containment-rpm-pxe.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar  8 12:06:24 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
+
+- Update to version 0.2.5:
+  * Add support for raw oem images
+
+-------------------------------------------------------------------
 Wed Jul 15 15:21:52 UTC 2020 - Alberto Planas Dominguez <aplanas@suse.com>
 
 - Update to version 0.2.4:

--- a/containment-rpm-pxe.spec
+++ b/containment-rpm-pxe.spec
@@ -17,7 +17,7 @@
 
 
 Name:           containment-rpm-pxe
-Version:        0.2.4
+Version:        0.2.5
 Release:        0
 Summary:        Wraps OBS/kiwi-built PXE images in rpms.
 License:        MIT

--- a/image.spec.in
+++ b/image.spec.in
@@ -38,13 +38,22 @@ __PROVIDES__
 __DESCRIPTION__
 
 %prep
+%if %{type} == raw
+%setup -T -c %{name}
+cp %{S:0} .
+%else
 %setup -q -c %{name}
+%endif
 
 %build
 
 %install
 cp %{SOURCE1} .
 
+%if %{type} == raw
+mkdir -p %{buildroot}__TARGET_IMAGE__
+install -p -m 644 __SOURCE_IMAGE__ %{buildroot}__TARGET_IMAGE__/__IMAGE__
+%else
 mkdir -p %{buildroot}__TARGET_BOOT__
 install -p -m 644 __SOURCE_KERNEL_BOOT__ %{buildroot}__TARGET_BOOT__/__KERNEL_BOOT__
 install -p -m 644 __SOURCE_INITRD_BOOT__ %{buildroot}__TARGET_BOOT__/__INITRD_BOOT__
@@ -60,6 +69,7 @@ install -p -m 644 __SOURCE_INITRD_IMAGE__ %{buildroot}__TARGET_IMAGE__/__INITRD_
 install -p -m 644 __SOURCE_APPEND__ %{buildroot}__TARGET_IMAGE__/__APPEND__
 %endif
 %endif
+%endif
 
 # If the kernel boot and image are the same, fix the link
 %fdupes -s %{buildroot}
@@ -67,8 +77,10 @@ install -p -m 644 __SOURCE_APPEND__ %{buildroot}__TARGET_IMAGE__/__APPEND__
 %files
 %defattr(644,root,root)
 %license __LICENSE_FILE__
+%if %{type} != raw
 %dir %attr(755, root, root) __TARGET_BOOT__
 %attr(644, root, root) __TARGET_BOOT__/*
+%endif
 %if %{ignore_image} == 0
 %dir %attr(755, root, root) __TARGET_IMAGE__
 %attr(644, root, root) __TARGET_IMAGE__/*

--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -37,7 +37,10 @@ get_xml_data() {
 }
 
 find_source() {
-    ls *.install.tar *.tar.xz 2> /dev/null || true
+    # Kiwi can generate both files, so look for *.raw.xz only
+    # if *.install.tar does not exist
+    #
+    ls *.install.tar *.tar.xz 2> /dev/null || ls *.raw.xz || true
 }
 
 parse_source() {
@@ -67,6 +70,12 @@ parse_source() {
 	    _cfg['sourceinitrdboot']="pxeboot*.initrd.xz"
             # "${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}.xz"
 	    _cfg['sourceimage']="${_cfg[name]}*.xz"
+	    ;;
+	*.raw.xz)
+	    _cfg['type']='raw'
+	    _cfg['sourcekernelboot']=
+	    _cfg['sourceinitrdboot']=
+	    _cfg['sourceimage']="${_cfg[name]}*.raw.xz"
 	    ;;
 	*)
 	    echo "ERROR: Unkown image type for ${source}"
@@ -133,7 +142,7 @@ parse_properties_xml() {
 	# "${_cfg[sourceappend]}"
 	['append']="${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}.append"
     )
-    if [ "${_cfg[type]}" == "oem" ]; then
+    if [ "${_cfg[type]}" == "oem" -o "${_cfg[type]}" == "raw" ]; then
 	_cfg['image']="${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}.xz"
     fi
 


### PR DESCRIPTION
This installs the raw.xz file without kernel/initrd.

Related to https://github.com/SUSE/spacewalk/issues/13655

