### PR TITLE
Add requirements for building images on SLE15 >= SP1

### DIFF
--- a/containment-rpm-pxe.changes
+++ b/containment-rpm-pxe.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  7 10:09:51 UTC 2021 - Julio González Gil <jgonzalez@suse.com>
+
+- Update to version 0.2.6:
+  * Require kiwi-systemdeps-disk-images, kiwi-systemdeps-image-validation,
+    kiwi-boot-descriptions to build images for SLE15SP1 and newer
+
+-------------------------------------------------------------------
 Mon Mar  8 12:06:24 UTC 2021 - Vladimir Nadvornik <nadvornik@suse.com>
 
 - Update to version 0.2.5:

--- a/containment-rpm-pxe.spec
+++ b/containment-rpm-pxe.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package containment-rpm-pxe
 #
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2021 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           containment-rpm-pxe
-Version:        0.2.5
+Version:        0.2.6
 Release:        0
 Summary:        Wraps OBS/kiwi-built PXE images in rpms.
 License:        MIT
@@ -28,6 +28,11 @@ BuildRequires:  filesystem
 Requires:       fdupes
 Requires:       libxml2-tools
 Requires:       perl-TimeDate
+%if 0%{?sle_version} >= 150100
+Requires:       kiwi-systemdeps-disk-images
+Requires:       kiwi-systemdeps-image-validation
+Requires:       kiwi-boot-descriptions
+%endif
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
Right now PXE images for SUSE Manager Head (based on SLE15SP1) do not build unless the three packages are added.

The SPEC was changed for testing at:

https://build.suse.de/project/show/home:juliogonzalezgil:branches:Devel:Galaxy:Manager:4.1
https://build.suse.de/project/show/home:juliogonzalezgil:branches:Devel:Galaxy:Manager:4.0
https://build.suse.de/project/show/home:juliogonzalezgil:branches:Devel:Galaxy:Manager:Head

As you can see the images are building in all cases. For 4.0 we'll need a SR for the pxe image to support newer containment-rpm-pxe versions (the change is on my branch already)

Reference: https://github.com/SUSE/spacewalk/issues/14483