### PR TITLE
Fix the hook after python-kiwi 9.24.16

### DIFF
--- a/containment-rpm-pxe.changes
+++ b/containment-rpm-pxe.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 22 10:53:06 UTC 2022 - Julio González Gil <jgonzalez@suse.com>
+
+- Update to version 0.2.7:
+  * The initrd images do are not xz compreessed anymore after
+    python-kiwi 9.24.16
+
+-------------------------------------------------------------------
 Wed Apr  7 10:09:51 UTC 2021 - Julio González Gil <jgonzalez@suse.com>
 
 - Update to version 0.2.6:

--- a/containment-rpm-pxe.spec
+++ b/containment-rpm-pxe.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package containment-rpm-pxe
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2022 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           containment-rpm-pxe
-Version:        0.2.6
+Version:        0.2.7
 Release:        0
 Summary:        Wraps OBS/kiwi-built PXE images in rpms.
 License:        MIT

--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -59,7 +59,7 @@ parse_source() {
 	*.tar.xz)
 	    _cfg['type']='pxe'
 	    _cfg['sourcekernelboot']="${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}-*.kernel"
-	    _cfg['sourceinitrdboot']="${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}.initrd.xz"
+	    _cfg['sourceinitrdboot']="${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}.initrd"
 	    _cfg['sourceimage']="${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}"
 	    ;;
 	*.install.tar)
@@ -67,7 +67,7 @@ parse_source() {
             # "pxeboot.${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}.kernel"
 	    _cfg['sourcekernelboot']="pxeboot*.kernel"
             # "pxeboot.${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}.initrd.xz"
-	    _cfg['sourceinitrdboot']="pxeboot*.initrd.xz"
+	    _cfg['sourceinitrdboot']="pxeboot*.initrd"
             # "${_cfg[name]}.${_cfg[arch]}-${_cfg[version]}.xz"
 	    _cfg['sourceimage']="${_cfg[name]}*.xz"
 	    ;;


### PR DESCRIPTION
https://build.opensuse.org/package/rdiff/SUSE:SLE-15-SP1:Update/python-kiwi?linkrev=base&rev=13 bumped python-kiwi to 9.24.16, and with that the initrd images are no longer xz compressed by default.

Talking to the developers, told me that you can't assume that xz is installed anymore, so we should just use uncompressed images. Since in the end we ship this as RPM, I am OK with the change, and removing the suffix fixes the problem.

